### PR TITLE
Feat: 이미지 타입 변경 사항 강의 수정페이지에도 적용

### DIFF
--- a/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/[segmentId]/edit/lecture-detail-edit-area.tsx
+++ b/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/[segmentId]/edit/lecture-detail-edit-area.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import { useAction } from '@core/react'
 import { useRouter } from 'next/navigation'
+import { useImgTypeState } from '@core/react/zustand/imgtype-store'
 import { type GetSegmentInclude } from '@/module/segment/model'
 import { convertToTimeFormatNumber } from '@/lib/util/convert-to-time-format-number'
 import { updateSegmentAction } from '@/module/segment/action'
@@ -20,9 +21,13 @@ interface LectureDetailEditAreaProps {
 	segment: GetSegmentInclude
 }
 
+const THUMBNAIL_IMG_BASE_URL = 'viliv.ngrok.dev/api/frames/'
+
 export function LectureDetailEditArea({
 	segment
 }: LectureDetailEditAreaProps) {
+	const imgType = useImgTypeState()
+
 	const [segmentTitle, setSegmentTitle] = useState(
 		segment.title
 	)
@@ -35,6 +40,11 @@ export function LectureDetailEditArea({
 	const [selectedFrames, setSelectedFrames] = useState<
 		number[]
 	>([])
+	const [lectureId, setLectureId] = useState(
+		segment.frames[0]?.frame
+			.replace(THUMBNAIL_IMG_BASE_URL, '')
+			.split('/')[0]
+	)
 
 	const router = useRouter()
 	const goBack = () => {
@@ -178,35 +188,40 @@ export function LectureDetailEditArea({
 						</div>
 					</div>
 					<div className="pc:grid-cols-5 pc:gap-2 grid grid-cols-1 gap-3">
-						{segment.frames.map((frame, index) => (
-							<div key={index} className="relative">
-								<Image
-									src={`https://${frame.frame}`}
-									alt="frame"
-									width={240}
-									height={150}
-									className={`aspect-video w-full cursor-pointer rounded-lg ${
-										selectedFrames.includes(index)
-											? 'border-primary border-[3px]'
-											: 'border-0'
-									}`}
-									onClick={() => handleFrameSelect(index)}
-								/>
-								<div className="text-background absolute bottom-2 left-2 px-2 py-1 text-sm font-medium">
-									{extractTimeFromFilename(frame.frame)}
+						{segment.frames.map((frame, index) => {
+							const frameImgUrl = !imgType
+								? frame.frame
+								: `${THUMBNAIL_IMG_BASE_URL}${lectureId}${imgType === 'default' ? '' : `/${imgType}`}/${frame.frameId}.jpg`
+							return (
+								<div key={index} className="relative">
+									<Image
+										src={`https://${frameImgUrl}`}
+										alt="frame"
+										width={240}
+										height={150}
+										className={`aspect-video w-full cursor-pointer rounded-lg ${
+											selectedFrames.includes(index)
+												? 'border-primary border-[3px]'
+												: 'border-0'
+										}`}
+										onClick={() => handleFrameSelect(index)}
+									/>
+									<div className="text-background absolute bottom-2 left-2 px-2 py-1 text-sm font-medium">
+										{extractTimeFromFilename(frame.frame)}
+									</div>
+									<div className="absolute right-2 top-2">
+										<Button
+											type="button"
+											size="sm"
+											options="icon"
+											disabled={!selectedFrames.includes(index)}
+										>
+											<Icon name="CheckLine" />
+										</Button>
+									</div>
 								</div>
-								<div className="absolute right-2 top-2">
-									<Button
-										type="button"
-										size="sm"
-										options="icon"
-										disabled={!selectedFrames.includes(index)}
-									>
-										<Icon name="CheckLine" />
-									</Button>
-								</div>
-							</div>
-						))}
+							)
+						})}
 					</div>
 				</div>
 				<div className="flex flex-col gap-2">

--- a/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/[segmentId]/edit/lecture-detail-edit-area.tsx
+++ b/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/[segmentId]/edit/lecture-detail-edit-area.tsx
@@ -193,7 +193,11 @@ export function LectureDetailEditArea({
 								? frame.frame
 								: `${THUMBNAIL_IMG_BASE_URL}${lectureId}${imgType === 'default' ? '' : `/${imgType}`}/${frame.frameId}.jpg`
 							return (
-								<div key={index} className="relative">
+								<div
+									onClick={() => handleFrameSelect(index)}
+									key={index}
+									className="relative"
+								>
 									<Image
 										src={`https://${frameImgUrl}`}
 										alt="frame"
@@ -204,7 +208,6 @@ export function LectureDetailEditArea({
 												? 'border-primary border-[3px]'
 												: 'border-0'
 										}`}
-										onClick={() => handleFrameSelect(index)}
 									/>
 									<div className="text-background absolute bottom-2 left-2 px-2 py-1 text-sm font-medium">
 										{extractTimeFromFilename(frame.frame)}

--- a/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-detail-area.tsx
+++ b/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-detail-area.tsx
@@ -22,6 +22,7 @@ const THUMBNAIL_IMG_BASE_URL = 'viliv.ngrok.dev/api/frames/'
 interface Frame {
 	frame: string
 	isThumbnail: boolean
+	frameId: string
 }
 
 interface LectureDetailAreaProps {
@@ -168,16 +169,12 @@ export function LectureDetailArea({
 									//thumbnailFrames.length > 0 : viliv.ngrok.dev/api/frames//cm2a4uoo2000113rj6bsjvxql/white_ver_dir/225.jpg
 									//thumbnailFrames.length <= 0 : viliv.ngrok.dev/api/frames/cm2a4l64d00012101y6xqkoe6/1695.jpg
 
-									const frameUrlWithInfos = frame.frame
+									const lectureId = frame.frame
 										.replace('//', '/')
 										.replace(THUMBNAIL_IMG_BASE_URL, '')
-										.split('/')
+										.split('/')[0]
 
-									const frameId = frameUrlWithInfos[0]
-									const imgNo =
-										frameUrlWithInfos[frameUrlWithInfos.length - 1]
-
-									const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${frameId}${imgType === 'default' ? '' : `/${imgType}`}/${imgNo}`
+									const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${lectureId}${imgType === 'default' ? '' : `/${imgType}`}/${frame.frameId}.jpg`
 
 									return {
 										...frame,

--- a/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-detail-area.tsx
+++ b/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-detail-area.tsx
@@ -6,6 +6,7 @@ import { Badge, Button } from '@design-system/ui'
 import Image from 'next/image'
 import { Icon } from '@design-system/icon'
 import Link from 'next/link'
+import { useImgTypeState } from '@core/react/zustand/imgtype-store'
 import defaultImage from '@/lib/asset/image/horizontal-default-image.png'
 import { type GetLectureInfo } from '@/module/lecture/model'
 import { downloadPDF } from '@/hook/download-pdf'
@@ -30,20 +31,16 @@ interface LectureDetailAreaProps {
 		lectureId: string
 	}
 	lecture: GetLectureInfo
-	type:
-		| undefined
-		| 'default'
-		| 'person_removed'
-		| 'white_ver_dir'
 }
 
 export function LectureDetailArea({
 	params,
-	lecture,
-	type
+	lecture
 }: LectureDetailAreaProps) {
 	const { analyzedLecture } = lecture //Result
 	const { segments = [] } = analyzedLecture || {}
+
+	const imgType = useImgTypeState()
 
 	const calculateSegmentDuration = (
 		textWithTimestamps: { timeStamp: number }[]
@@ -75,7 +72,7 @@ export function LectureDetailArea({
 	}
 
 	const handleDownloadPDF = async () => {
-		const url = `${window.location.origin}/pdf/${lecture.id}${type ? `?type=${type}` : ''}`
+		const url = `${window.location.origin}/pdf/${lecture.id}?type=${imgType}}`
 
 		await downloadPDF(url)
 	}
@@ -165,7 +162,7 @@ export function LectureDetailArea({
 							]
 						}
 
-						if (type) {
+						if (imgType) {
 							framesToDisplay = framesToDisplay.map(
 								(frame: Frame) => {
 									//thumbnailFrames.length > 0 : viliv.ngrok.dev/api/frames//cm2a4uoo2000113rj6bsjvxql/white_ver_dir/225.jpg
@@ -180,7 +177,7 @@ export function LectureDetailArea({
 									const imgNo =
 										frameUrlWithInfos[frameUrlWithInfos.length - 1]
 
-									const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${frameId}/${type === 'default' ? '' : `/${type}`}/${imgNo}`
+									const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${frameId}${imgType === 'default' ? '' : `/${imgType}`}/${imgNo}`
 
 									return {
 										...frame,

--- a/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-detail-header.tsx
+++ b/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-detail-header.tsx
@@ -9,6 +9,7 @@ import {
 	DropdownMenuTrigger
 } from '@design-system/ui'
 import { useRouter } from 'next/navigation'
+import { useImgTypeState } from '@core/react/zustand/imgtype-store'
 import { type GetLectureInfo } from '@/module/lecture/model'
 import { downloadPDF } from '@/hook/download-pdf'
 import { LectureInfo } from './lecture-info'
@@ -21,25 +22,21 @@ interface LectureDetailHeaderProps {
 		lectureId: string
 	}
 	lecture: GetLectureInfo
-	type:
-		| 'default'
-		| 'person_removed'
-		| 'white_ver_dir'
-		| undefined
 }
 
 export function LectureDetailHeader({
 	params,
-	lecture,
-	type
+	lecture
 }: LectureDetailHeaderProps) {
+	const imgType = useImgTypeState()
+
 	const router = useRouter()
 	const goBack = () => {
 		router.back()
 	}
 
 	const handleDownloadPDF = async () => {
-		const url = `${window.location.origin}/pdf/${params.lectureId}${type ? `?type=${type}` : ''}`
+		const url = `${window.location.origin}/pdf/${params.lectureId}?type=${imgType}}`
 		await downloadPDF(url)
 	}
 

--- a/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-img-type-select.tsx
+++ b/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-img-type-select.tsx
@@ -35,7 +35,7 @@ export function LectureImgTypeSelect({
 	return (
 		<Select
 			onValueChange={handleImgTypeSelect}
-			value={typeof imgType === 'string' ? imgType : undefined}
+			value={imgType ?? undefined}
 		>
 			<SelectTrigger
 				className="h-fit w-fit"

--- a/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-img-type-select.tsx
+++ b/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-img-type-select.tsx
@@ -6,26 +6,37 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@design-system/ui'
-import { useRouter } from 'next/navigation'
+import {
+	useImgTypeState,
+	useImgTypeStateAction
+} from '@core/react/zustand/imgtype-store'
 
 interface LectureImgTypeSelectProps {
 	size?: 'sm' | 'md'
 }
 
+type LectureImgType =
+	| 'default'
+	| 'person_removed'
+	| 'white_ver_dir'
+
 export function LectureImgTypeSelect({
 	size = 'md'
 }: LectureImgTypeSelectProps) {
-	const router = useRouter()
+	const imgType = useImgTypeState()
+	const setImgType = useImgTypeStateAction()
 
-	const handleImgTypeSelect = (selectedType: string) => {
-		// get current url
-		const currentUrl = window.location.href.split('?')[0]
-
-		router.push(`${currentUrl}?type=${selectedType}`)
+	const handleImgTypeSelect = (
+		selectedType: LectureImgType
+	) => {
+		setImgType(selectedType)
 	}
 
 	return (
-		<Select onValueChange={handleImgTypeSelect}>
+		<Select
+			onValueChange={handleImgTypeSelect}
+			value={typeof imgType === 'string' ? imgType : undefined}
+		>
 			<SelectTrigger
 				className="h-fit w-fit"
 				style={{ fontSize: `${size === 'sm' ? '14' : '16'}px` }}

--- a/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/page.tsx
+++ b/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/page.tsx
@@ -25,16 +25,8 @@ export default async function LectureDetailPage({
 
 	return (
 		<div className="max-pc:bg-background">
-			<LectureDetailHeader
-				lecture={lecture}
-				params={params}
-				type={type}
-			/>
-			<LectureDetailArea
-				lecture={lecture}
-				params={params}
-				type={type}
-			/>
+			<LectureDetailHeader lecture={lecture} params={params} />
+			<LectureDetailArea lecture={lecture} params={params} />
 		</div>
 	)
 }

--- a/apps/academy/src/app/pdf/[lectureId]/_ui/pdf-area.tsx
+++ b/apps/academy/src/app/pdf/[lectureId]/_ui/pdf-area.tsx
@@ -11,11 +11,7 @@ const THUMBNAIL_IMG_BASE_URL = 'viliv.ngrok.dev/api/frames/'
 
 interface PDFAreaProps {
 	lecture: GetLectureInfo
-	type:
-		| 'default'
-		| 'person_removed'
-		| 'white_ver_dir'
-		| undefined
+	type: 'default' | 'person_removed' | 'white_ver_dir' | ''
 }
 
 function formatTimestamp(ms: number): string {

--- a/apps/academy/src/app/pdf/[lectureId]/_ui/pdf-area.tsx
+++ b/apps/academy/src/app/pdf/[lectureId]/_ui/pdf-area.tsx
@@ -101,16 +101,12 @@ export function PDFArea({ lecture, type }: PDFAreaProps) {
 					: finedThumbnailFrames.map((frame) => {
 							if (!frame) return frame
 
-							const frameUrlWithInfos = frame.frame
+							const lectureId = frame.frame
 								.replace('//', '/')
 								.replace(THUMBNAIL_IMG_BASE_URL, '')
-								.split('/')
+								.split('/')[0]
 
-							const frameId = frameUrlWithInfos[0]
-							const imgNo =
-								frameUrlWithInfos[frameUrlWithInfos.length - 1]
-
-							const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${frameId}/${type === 'default' ? '' : `/${type}`}/${imgNo}`
+							const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${lectureId}${type === 'default' ? '' : `/${type}`}/${frame.frameId}.jpg`
 
 							return {
 								...frame,

--- a/apps/academy/src/app/pdf/[lectureId]/page.tsx
+++ b/apps/academy/src/app/pdf/[lectureId]/page.tsx
@@ -6,7 +6,7 @@ interface LecturePDFPageProps {
 		lectureId: string
 	}
 	searchParams: {
-		type?: 'default' | 'person_removed' | 'white_ver_dir'
+		type?: 'default' | 'person_removed' | 'white_ver_dir' | ''
 	}
 }
 
@@ -17,7 +17,7 @@ export default async function LecturePDFPage({
 	const lecture = await lectureService.getLectureInfo(
 		params.lectureId
 	)
-	const { type } = searchParams
+	const { type = '' } = searchParams
 
 	return (
 		<div>

--- a/apps/student/src/app/academy/[classId]/_ui/lecture-detail-area.tsx
+++ b/apps/student/src/app/academy/[classId]/_ui/lecture-detail-area.tsx
@@ -23,6 +23,7 @@ interface LectureDetailAreaProps {
 interface Frame {
 	frame: string
 	isThumbnail: boolean
+	frameId: string
 }
 
 export function LectureDetailArea({
@@ -151,16 +152,12 @@ export function LectureDetailArea({
 									//thumbnailFrames.length > 0 : viliv.ngrok.dev/api/frames//cm2a4uoo2000113rj6bsjvxql/white_ver_dir/225.jpg
 									//thumbnailFrames.length <= 0 : viliv.ngrok.dev/api/frames/cm2a4l64d00012101y6xqkoe6/1695.jpg
 
-									const frameUrlWithInfos = frame.frame
+									const lectureId = frame.frame
 										.replace('//', '/')
 										.replace(THUMBNAIL_IMG_BASE_URL, '')
-										.split('/')
+										.split('/')[0]
 
-									const frameId = frameUrlWithInfos[0]
-									const imgNo =
-										frameUrlWithInfos[frameUrlWithInfos.length - 1]
-
-									const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${frameId}${imgType === 'default' ? '' : `/${imgType}`}/${imgNo}`
+									const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${lectureId}${imgType === 'default' ? '' : `/${imgType}`}/${frame.frameId}.jpg`
 
 									return {
 										...frame,

--- a/apps/student/src/app/academy/[classId]/_ui/lecture-detail-area.tsx
+++ b/apps/student/src/app/academy/[classId]/_ui/lecture-detail-area.tsx
@@ -5,6 +5,7 @@ import { useRef } from 'react'
 import { Badge, Button } from '@design-system/ui'
 import Image from 'next/image'
 import { Icon } from '@design-system/icon'
+import { useImgTypeState } from '@core/react/zustand/imgtype-store'
 import defaultImage from '@/lib/asset/image/horizontal-default-image.png'
 import { type GetLectureInfo } from '@/module/lecture/model'
 import { downloadPDF } from '@/hook/download-pdf'
@@ -17,11 +18,6 @@ const THUMBNAIL_IMG_BASE_URL = 'viliv.ngrok.dev/api/frames/'
 
 interface LectureDetailAreaProps {
 	lecture: GetLectureInfo
-	type:
-		| 'default'
-		| 'person_removed'
-		| 'white_ver_dir'
-		| undefined
 }
 
 interface Frame {
@@ -30,11 +26,12 @@ interface Frame {
 }
 
 export function LectureDetailArea({
-	lecture,
-	type
+	lecture
 }: LectureDetailAreaProps) {
 	const { analyzedLecture } = lecture
 	const { segments = [] } = analyzedLecture || {}
+
+	const imgType = useImgTypeState()
 
 	const calculateSegmentDuration = (
 		textWithTimestamps: { timeStamp: number }[]
@@ -66,8 +63,7 @@ export function LectureDetailArea({
 	}
 
 	const handleDownloadPDF = async () => {
-		const url = `${window.location.origin}/pdf/${lecture.id}${type ? `?type=${type}` : ''}`
-		console.log(url)
+		const url = `${window.location.origin}/pdf/${lecture.id}?type=${imgType}}`
 		await downloadPDF(url)
 	}
 
@@ -149,7 +145,7 @@ export function LectureDetailArea({
 							]
 						}
 
-						if (type) {
+						if (imgType) {
 							framesToDisplay = framesToDisplay.map(
 								(frame: Frame) => {
 									//thumbnailFrames.length > 0 : viliv.ngrok.dev/api/frames//cm2a4uoo2000113rj6bsjvxql/white_ver_dir/225.jpg
@@ -164,7 +160,7 @@ export function LectureDetailArea({
 									const imgNo =
 										frameUrlWithInfos[frameUrlWithInfos.length - 1]
 
-									const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${frameId}/${type === 'default' ? '' : `/${type}`}/${imgNo}`
+									const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${frameId}${imgType === 'default' ? '' : `/${imgType}`}/${imgNo}`
 
 									return {
 										...frame,

--- a/apps/student/src/app/academy/[classId]/_ui/lecture-detail-header.tsx
+++ b/apps/student/src/app/academy/[classId]/_ui/lecture-detail-header.tsx
@@ -3,6 +3,7 @@
 import { Icon } from '@design-system/icon'
 import { Button } from '@design-system/ui'
 import { useRouter } from 'next/navigation'
+import { useImgTypeState } from '@core/react/zustand/imgtype-store'
 import { type GetLectureInfo } from '@/module/lecture/model'
 import { downloadPDF } from '@/hook/download-pdf'
 import { LectureInfo } from './lecture-info'
@@ -13,25 +14,21 @@ interface LectureDetailHeaderProps {
 		lectureId: string
 	}
 	lecture: GetLectureInfo
-	type:
-		| 'default'
-		| 'person_removed'
-		| 'white_ver_dir'
-		| undefined
 }
 
 export function LectureDetailHeader({
 	params,
-	lecture,
-	type
+	lecture
 }: LectureDetailHeaderProps) {
+	const imgType = useImgTypeState()
+
 	const router = useRouter()
 	const goBack = () => {
 		router.back()
 	}
 
 	const handleDownloadPDF = async () => {
-		const url = `${window.location.origin}/pdf/${params.lectureId}${type ? `?type=${type}` : ''}`
+		const url = `${window.location.origin}/pdf/${params.lectureId}?type=${imgType}}`
 		await downloadPDF(url)
 	}
 

--- a/apps/student/src/app/academy/[classId]/_ui/lecture-img-type-select.tsx
+++ b/apps/student/src/app/academy/[classId]/_ui/lecture-img-type-select.tsx
@@ -35,7 +35,7 @@ export function LectureImgTypeSelect({
 	return (
 		<Select
 			onValueChange={handleImgTypeSelect}
-			value={typeof imgType === 'string' ? imgType : undefined}
+			value={imgType ?? undefined}
 		>
 			<SelectTrigger
 				className="h-fit w-fit"

--- a/apps/student/src/app/academy/[classId]/_ui/lecture-img-type-select.tsx
+++ b/apps/student/src/app/academy/[classId]/_ui/lecture-img-type-select.tsx
@@ -6,26 +6,37 @@ import {
 	SelectTrigger,
 	SelectValue
 } from '@design-system/ui'
-import { useRouter } from 'next/navigation'
+import {
+	useImgTypeState,
+	useImgTypeStateAction
+} from '@core/react/zustand/imgtype-store'
 
 interface LectureImgTypeSelectProps {
 	size?: 'sm' | 'md'
 }
 
+type LectureImgType =
+	| 'default'
+	| 'person_removed'
+	| 'white_ver_dir'
+
 export function LectureImgTypeSelect({
 	size = 'md'
 }: LectureImgTypeSelectProps) {
-	const router = useRouter()
+	const imgType = useImgTypeState()
+	const setImgType = useImgTypeStateAction()
 
-	const handleImgTypeSelect = (selectedType: string) => {
-		// get current url
-		const currentUrl = window.location.href.split('?')[0]
-
-		router.push(`${currentUrl}?type=${selectedType}`)
+	const handleImgTypeSelect = (
+		selectedType: LectureImgType
+	) => {
+		setImgType(selectedType)
 	}
 
 	return (
-		<Select onValueChange={handleImgTypeSelect}>
+		<Select
+			onValueChange={handleImgTypeSelect}
+			value={typeof imgType === 'string' ? imgType : undefined}
+		>
 			<SelectTrigger
 				className="h-fit w-fit"
 				style={{ fontSize: `${size === 'sm' ? '14' : '16'}px` }}

--- a/apps/student/src/app/academy/[classId]/lecture/[lectureId]/detail/page.tsx
+++ b/apps/student/src/app/academy/[classId]/lecture/[lectureId]/detail/page.tsx
@@ -6,29 +6,20 @@ interface LectureDetailPageProps {
 	params: {
 		lectureId: string
 	}
-	searchParams: {
-		type?: 'default' | 'person_removed' | 'white_ver_dir'
-	}
 }
 
 export default async function LectureDetailPage({
-	params,
-	searchParams
+	params
 }: LectureDetailPageProps) {
 	const { lectureId } = params
-	const { type } = searchParams // 쿼리 파라미터로부터 썸네일 이미지 type 가져오기, 기본값은 'default'
 
 	const lecture =
 		await lectureService.getLectureInfo(lectureId)
 
 	return (
 		<div className="max-pc:bg-background">
-			<LectureDetailHeader
-				lecture={lecture}
-				params={params}
-				type={type}
-			/>
-			<LectureDetailArea lecture={lecture} type={type} />
+			<LectureDetailHeader lecture={lecture} params={params} />
+			<LectureDetailArea lecture={lecture} />
 		</div>
 	)
 }

--- a/apps/student/src/app/pdf/[lectureId]/_ui/pdf-area.tsx
+++ b/apps/student/src/app/pdf/[lectureId]/_ui/pdf-area.tsx
@@ -106,16 +106,12 @@ export function PDFArea({ lecture, type }: PDFAreaProps) {
 					: finedThumbnailFrames.map((frame) => {
 							if (!frame) return frame
 
-							const frameUrlWithInfos = frame.frame
+							const lectureId = frame.frame
 								.replace('//', '/')
 								.replace(THUMBNAIL_IMG_BASE_URL, '')
-								.split('/')
+								.split('/')[0]
 
-							const frameId = frameUrlWithInfos[0]
-							const imgNo =
-								frameUrlWithInfos[frameUrlWithInfos.length - 1]
-
-							const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${frameId}/${type === 'default' ? '' : `/${type}`}/${imgNo}`
+							const thumbnailUrlToDisplay = `${THUMBNAIL_IMG_BASE_URL}${lectureId}${type === 'default' ? '' : `/${type}`}/${frame.frameId}.jpg`
 
 							return {
 								...frame,

--- a/packages/core/react/zustand/imgtype-store.ts
+++ b/packages/core/react/zustand/imgtype-store.ts
@@ -12,13 +12,16 @@ interface ImgTypeProps {
 
 const useImgTypeStore = create(
   persist<ImgTypeProps>(
-    (set) => ({
-      type: get(StorageKey) as unknown as ImgTypeProps['type'] || null,
-
+    (set) => {
+			const getInitImgType = get(StorageKey) as unknown as ImgTypeProps['type'] 
+			return ({
+      type: typeof getInitImgType === 'string' ? getInitImgType : null,
       setType: (type: ImgTypeProps['type']) => {
         set({ type });
       },
-    }),
+    })
+		}
+,
     {
       name: StorageKey, 
     },

--- a/packages/core/react/zustand/imgtype-store.ts
+++ b/packages/core/react/zustand/imgtype-store.ts
@@ -1,0 +1,32 @@
+import { get } from 'http';
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+const StorageKey = 'img-type'
+
+interface ImgTypeProps {
+	type:  null | 'default' | 'person_removed'| 'white_ver_dir',
+	setType: (type: ImgTypeProps['type']) => void
+}
+
+
+const useImgTypeStore = create(
+  persist<ImgTypeProps>(
+    (set) => ({
+      type: get(StorageKey) as unknown as ImgTypeProps['type'] || null,
+
+      setType: (type: ImgTypeProps['type']) => {
+        set({ type });
+      },
+    }),
+    {
+      name: StorageKey, 
+    },
+  ),
+);
+
+export const useImgTypeState = () => 
+	useImgTypeStore((state) => state.type);
+	
+	export const useImgTypeStateAction = () =>
+		useImgTypeStore((state) => state.setType);


### PR DESCRIPTION
## 요약
- 이미지 타입 변경시 강의 수정페이지에서도 바뀐 이미지 타입 적용되도록 구현
- 이미지 종류 바꾸고 뒤로가기 눌렀을 때 router.push()로 이미지 종류 바꿨던 히스토리대로 돌아갔던 오류 해결
- 수정할 때 강의 타임라인 이미지 말고 체크버튼 눌러도 선택되게도록 수정

