### PR TITLE
feat: 강의 전체 요약 text 스크롤 기능

### DIFF
--- a/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-detail-area.tsx
+++ b/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-detail-area.tsx
@@ -129,7 +129,9 @@ export function LectureDetailArea({
 							</div>
 							<SummaryEditModal lecture={lecture} />
 						</div>
-						<div className="text-sm">{lecture.description}</div>
+						<div className="max-h-[320px] overflow-y-auto text-sm">
+							{lecture.description}
+						</div>
 					</div>
 					<div className="bg-secondary flex items-center justify-between rounded-md p-6">
 						<div className="text-base font-semibold">

--- a/apps/student/src/app/academy/[classId]/_ui/lecture-detail-area.tsx
+++ b/apps/student/src/app/academy/[classId]/_ui/lecture-detail-area.tsx
@@ -118,7 +118,9 @@ export function LectureDetailArea({
 								강의 전체 요약
 							</div>
 						</div>
-						<div className="text-sm">{lecture.description}</div>
+						<div className="max-h-[320px] overflow-y-auto text-sm">
+							{lecture.description}
+						</div>
 					</div>
 				</div>
 				<div className="bg-background pc:w-1/2 flex flex-col gap-4 rounded-md p-4 shadow">


### PR DESCRIPTION
## 요약
- academy, student lecture detail 페이지의 강의 전체 요약 text 스크롤 기능 구현 (height 320px 이상 시 스크롤)

## 상세 내용

- 

## 참고 사항

(관련 자료가 있다면 여기에 입력해주세요. 예를 들어, 이슈 링크, 코드 리뷰 링크 등을 입력할 수 있습니다.)
