### PR TITLE
fix: 스크롤 허용해도 강의 공개 여부 섹션 안보이는 에러

### DIFF
--- a/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-detail-area.tsx
+++ b/apps/academy/src/app/academy/[academyId]/student/[classId]/lecture/[lectureId]/detail/_ui/lecture-detail-area.tsx
@@ -129,7 +129,7 @@ export function LectureDetailArea({
 							</div>
 							<SummaryEditModal lecture={lecture} />
 						</div>
-						<div className="max-h-[320px] overflow-y-auto text-sm">
+						<div className="max-h-[228px] overflow-y-auto text-sm">
 							{lecture.description}
 						</div>
 					</div>

--- a/apps/student/src/app/academy/[classId]/_ui/lecture-detail-area.tsx
+++ b/apps/student/src/app/academy/[classId]/_ui/lecture-detail-area.tsx
@@ -118,7 +118,7 @@ export function LectureDetailArea({
 								강의 전체 요약
 							</div>
 						</div>
-						<div className="max-h-[320px] overflow-y-auto text-sm">
+						<div className="max-h-[228px] overflow-y-auto text-sm">
 							{lecture.description}
 						</div>
 					</div>

--- a/apps/student/src/app/academy/[classId]/_ui/lecture-detail-area.tsx
+++ b/apps/student/src/app/academy/[classId]/_ui/lecture-detail-area.tsx
@@ -118,7 +118,7 @@ export function LectureDetailArea({
 								강의 전체 요약
 							</div>
 						</div>
-						<div className="max-h-[228px] overflow-y-auto text-sm">
+						<div className="max-h-[320px] overflow-y-auto text-sm">
 							{lecture.description}
 						</div>
 					</div>


### PR DESCRIPTION
## 요약
- academy 사이트의 강의 상세 페이지에서 강의 전체 요약 부분 스크롤 허용해도 강의 공개 여부 섹션이 안보이는 에러 해결

## 상세 내용

- 

## 참고 사항

(관련 자료가 있다면 여기에 입력해주세요. 예를 들어, 이슈 링크, 코드 리뷰 링크 등을 입력할 수 있습니다.)
